### PR TITLE
Quarkus Rest client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 build/
 /.vscode/
 
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/fxapps/llmfx/Model.java
+++ b/src/main/java/org/fxapps/llmfx/Model.java
@@ -63,4 +63,6 @@ public class Model {
         }
     }
 
+    
+
 }

--- a/src/main/java/org/fxapps/llmfx/services/BearerTokenHeaderFactory.java
+++ b/src/main/java/org/fxapps/llmfx/services/BearerTokenHeaderFactory.java
@@ -1,0 +1,24 @@
+package org.fxapps.llmfx.services;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.fxapps.llmfx.config.LLMConfig;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+/**
+ * adds the bearer token to the request headers
+ */
+public class BearerTokenHeaderFactory implements ClientHeadersFactory {
+
+    @Inject
+    LLMConfig llmConfig;
+    
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders, MultivaluedMap<String, String> clientOutgoingHeaders) {
+        MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+        llmConfig.key().ifPresent(key -> result.add("Authorization", "Bearer " + key));
+        return result;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.log.category."dev.langchain4j".level=INFO
 quarkus.package.jar.type=uber-jar
 quarkus.fx.views-root=screens
 llm.model=qwen2.5:latest
-llm.url=http://localhost:1234/v1
+llm.url=http://localhost:11434/v1
 llm.timeout=2000
 # Sample usage of MCP Servers
 #mcp.servers.jdbc.commands=jbang,jdbc@quarkiverse/quarkus-mcp-servers,jdbc:sqlite:./database.db


### PR DESCRIPTION
i noticed it was using http restclient which can have issues so made this that uses quarkus rest client instead.

Then realized when things go bad (i.e. if default url is not working) then it either fails silently or if slow to load ui never shows.

thus:
- moved to quarkus client
- move loading/init to runLater so main screen shown always/faster
- show error if model fail to load
- change default properties to where ollama would run so it at least works when having ollama running

I saw there was explicit http1.1 enablement...we can do that but what client/server has issue with that? the rest client should negotiate it correctly?